### PR TITLE
feat: implement meilisearch container

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,8 @@
 
   <properties>
     <testcontainers>1.18.0</testcontainers>
+    <junit-jupiter>5.7.0</junit-jupiter>
+    <assertj-core>3.18.1</assertj-core>
   </properties>
 
   <dependencies>
@@ -17,6 +19,19 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
       <version>${testcontainers}</version>
+    </dependency>
+    <!-- Test -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit-jupiter}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${assertj-core}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
     <testcontainers>1.18.0</testcontainers>
     <junit-jupiter>5.7.0</junit-jupiter>
     <assertj-core>3.18.1</assertj-core>
+    <logback>1.2.9</logback>
   </properties>
 
   <dependencies>
@@ -31,6 +32,12 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>${assertj-core}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${logback}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,4 +7,16 @@
   <groupId>io.vanslog</groupId>
   <artifactId>testcontainers-meilisearch</artifactId>
   <version>1.0.0-SNAPSHOT</version>
+
+  <properties>
+    <testcontainers>1.18.0</testcontainers>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>${testcontainers}</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,12 @@
     </dependency>
     <!-- Test -->
     <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${testcontainers}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <version>${junit-jupiter}</version>

--- a/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
+++ b/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
@@ -1,6 +1,9 @@
 package io.vanslog.testcontainers.meilisearch;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.utility.DockerImageName;
 
 /**
@@ -11,8 +14,9 @@ import org.testcontainers.utility.DockerImageName;
  */
 public class MeilisearchContainer extends GenericContainer<MeilisearchContainer> {
 
-  private static final int MEILISEARCH_DEFAULT_PORT = 7700;
+  Logger log = LoggerFactory.getLogger(MeilisearchContainer.class);
 
+  private static final int MEILISEARCH_DEFAULT_PORT = 7700;
   private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("getmeili/meilisearch");
   private static final String DEFAULT_IMAGE_TAG = "latest";
 
@@ -30,5 +34,6 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
   public MeilisearchContainer(DockerImageName dockerImageName) {
     super(dockerImageName);
     this.addExposedPort(MEILISEARCH_DEFAULT_PORT);
+    this.withLogConsumer(new Slf4jLogConsumer(log));
   }
 }

--- a/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
+++ b/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
@@ -1,0 +1,34 @@
+package io.vanslog.testcontainers.meilisearch;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Container for Meilisearch
+ *
+ * @since 1.0
+ * @author Junghoon Ban
+ */
+public class MeilisearchContainer extends GenericContainer<MeilisearchContainer> {
+
+  private static final int MEILISEARCH_DEFAULT_PORT = 7700;
+
+  private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("getmeili/meilisearch");
+  private static final String DEFAULT_IMAGE_TAG = "latest";
+
+  /**
+   * Create a Meilisearch container with default settings
+   */
+  public MeilisearchContainer() {
+    this(DEFAULT_IMAGE_NAME.withTag(DEFAULT_IMAGE_TAG));
+  }
+
+  /**
+   * Create a Meilisearch container with a specific version
+   * @param dockerImageName The docker image name to use
+   */
+  public MeilisearchContainer(DockerImageName dockerImageName) {
+    super(dockerImageName);
+    this.addExposedPort(MEILISEARCH_DEFAULT_PORT);
+  }
+}

--- a/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerTest.java
+++ b/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerTest.java
@@ -1,0 +1,37 @@
+package io.vanslog.testcontainers.meilisearch;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MeilisearchContainerTest {
+
+  private static final MeilisearchContainer meilisearchContainer = new MeilisearchContainer();
+
+  @BeforeAll
+  public static void setup() {
+    meilisearchContainer.start();
+  }
+
+  @AfterAll
+  public static void cleanup() {
+    meilisearchContainer.stop();
+  }
+
+  @Test
+  void shouldStartMeilisearch() {
+    assertThat(meilisearchContainer.isRunning()).isTrue();
+  }
+
+  @Test
+  void shouldGetHost() {
+    assertThat(meilisearchContainer.getHost()).isEqualTo("localhost");
+  }
+
+  @Test
+  void getPort() {
+    assertThat(meilisearchContainer.getMappedPort(7700)).isNotNull();
+  }
+}

--- a/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerTest.java
+++ b/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerTest.java
@@ -1,24 +1,21 @@
 package io.vanslog.testcontainers.meilisearch;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MeilisearchContainerTest {
+/**
+ * Unit tests for {@link MeilisearchContainer}.
+ *
+ * @author Junghoon Ban
+ */
+@Testcontainers
+class MeilisearchContainerTest {
 
+  @Container
   private static final MeilisearchContainer meilisearchContainer = new MeilisearchContainer();
-
-  @BeforeAll
-  public static void setup() {
-    meilisearchContainer.start();
-  }
-
-  @AfterAll
-  public static void cleanup() {
-    meilisearchContainer.stop();
-  }
 
   @Test
   void shouldStartMeilisearch() {


### PR DESCRIPTION
Related Issue
---

#1 

Description
---

It's easy to run a `Meilisearch` instance on test code in the following ways

```java
@Container
MeilisearchContainer container = new MeilisearchContainer();
```