### PR TITLE
refactor: provide fixed default image version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,44 @@ DockerImageName imageName = DockerImageName.parse("getmeili/meilisearch:latest")
 @Container
 MeiliSearchContainer container = new MeiliSearchContainer(imageName);
 ```
+
+Dependency
+---
+
+> **Note**
+> This project is not available in `Maven Central` repository.
+> So you need to add the `Sonatype Snapshots` repository to your build file.
+
+### Gradle
+
+```groovy
+// build.gradle
+repositories {
+    mavenCentral()
+    maven {
+        url 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
+    }
+}
+
+testImplementation 'io.vanslog:testcontainers-meilisearch:1.0.0-SNAPSHOT'
+```
+
+### Maven
+
+```xml
+<!-- pom.xml -->
+<repositories>
+    <repository>
+        <id>sonatype-snapshots</id>
+        <name>Sonatype Snapshots</name>
+        <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+    </repository>
+</repositories>
+
+<dependency>
+    <groupId>io.vanslog</groupId>
+    <artifactId>testcontainers-meilisearch</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <scope>test</scope>
+</dependency>
+```

--- a/README.md
+++ b/README.md
@@ -2,3 +2,24 @@ Testcontainers Meilisearch
 ===
 
 A [Testcontainers](https://www.testcontainers.org/) implementation for [Meilisearch](https://www.meilisearch.com/).
+
+How to use
+---
+
+You can use the `@Container` annotation to start a Meilisearch container.
+
+### Default image
+
+```java
+@Container
+MeiliSearchContainer container = new MeiliSearchContainer();
+```
+
+### Custom image
+
+```java
+DockerImageName imageName = DockerImageName.parse("getmeili/meilisearch:latest");
+
+@Container
+MeiliSearchContainer container = new MeiliSearchContainer(imageName);
+```

--- a/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
+++ b/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
@@ -18,7 +18,7 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
 
   private static final int MEILISEARCH_DEFAULT_PORT = 7700;
   private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("getmeili/meilisearch");
-  private static final String DEFAULT_IMAGE_TAG = "latest";
+  private static final String DEFAULT_IMAGE_TAG = "v1.2.0";
 
   /**
    * Create a Meilisearch container with default settings


### PR DESCRIPTION
Related Issue
---

#9 

Description
---

Specify the version of the base image as `v1.2.0`.