### PR TITLE
feat: set master key

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can use the `@Container` annotation to start a Meilisearch container.
 
 ```java
 @Container
-MeiliSearchContainer container = new MeiliSearchContainer();
+MeilisearchContainer container = new MeilisearchContainer();
 ```
 
 ### Custom image
@@ -21,8 +21,15 @@ MeiliSearchContainer container = new MeiliSearchContainer();
 DockerImageName imageName = DockerImageName.parse("getmeili/meilisearch:latest");
 
 @Container
-MeiliSearchContainer container = new MeiliSearchContainer(imageName);
+MeilisearchContainer container = new MeilisearchContainer(imageName);
 ```
+
+### Set master key
+
+```java
+@Container
+MeilisearchContainer container = new MeilisearchContainer()
+    .withMasterKey("masterKey");
 
 Dependency
 ---

--- a/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
+++ b/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
@@ -36,4 +36,14 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
     this.addExposedPort(MEILISEARCH_DEFAULT_PORT);
     this.withLogConsumer(new Slf4jLogConsumer(log));
   }
+
+  /**
+   * Configure master key
+   * @param masterKey A master key to use
+   * @return The current instance of the Meilisearch container
+   */
+  public MeilisearchContainer withMasterKey(String masterKey) {
+    this.addEnv("MEILI_MASTER_KEY", masterKey);
+    return self();
+  }
 }

--- a/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerTest.java
+++ b/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerTest.java
@@ -15,7 +15,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class MeilisearchContainerTest {
 
   @Container
-  private static final MeilisearchContainer meilisearchContainer = new MeilisearchContainer();
+  private static final MeilisearchContainer meilisearchContainer = new MeilisearchContainer()
+      .withMasterKey("masterKey");
 
   @Test
   void shouldStartMeilisearch() {


### PR DESCRIPTION
Related Issue
---

#12 

Description
---

A master key can be set up in the following ways

```java
@Container
MeilisearchContainer container = new MeilisearchContainer()
    .withMasterKey("masterKey");
```

