### PR TITLE
chore(github): set sonar properties as command options

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,4 +29,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn verify sonar:sonar -Pcoverage
+        run: >
+          mvn verify sonar:sonar -Pcoverage
+          -Dsonar.host.url=https://sonarcloud.io
+          -Dsonar.organization=junghoon-ban
+          -Dsonar.projectKey=testcontainers-meilisearch

--- a/pom.xml
+++ b/pom.xml
@@ -24,10 +24,6 @@
     <!-- Compiler -->
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <!-- SonarCloud -->
-    <sonar.organization>junghoon-ban</sonar.organization>
-    <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-    <sonar.projectKey>testcontainers-meilisearch</sonar.projectKey>
     <!-- Dependencies -->
     <testcontainers>1.18.0</testcontainers>
     <junit-jupiter>5.7.0</junit-jupiter>


### PR DESCRIPTION
Description
---

I moved all the sonarcloud related settings that I was managing in the pom.xml to GitHub actions.

AS-IS
---

```yml
- name: Build and analyze
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
  run: mvn verify sonar:sonar -Pcoverage
```

```xml
<!-- pom.xml -->

<properties>
    <!-- SonarCloud -->
    <sonar.organization>junghoon-ban</sonar.organization>
    <sonar.host.url>https://sonarcloud.io</sonar.host.url>
    <sonar.projectKey>testcontainers-meilisearch</sonar.projectKey>
</properties>
```

TO-BE
---

```yml
- name: Build and analyze
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
  run: >
    mvn verify sonar:sonar -Pcoverage
    -Dsonar.host.url=https://sonarcloud.io
    -Dsonar.organization=junghoon-ban
    -Dsonar.projectKey=testcontainers-meilisearch
```