### PR TITLE
fix(github): disable ryuk in testcontainers on ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          TESTCONTAINERS_RYUK_DISABLED: true
         run: >
           mvn verify sonar:sonar -Pcoverage
           -Dsonar.host.url=https://sonarcloud.io


### PR DESCRIPTION
## Related Issue

#18 

## Description

The `ryuk` performs fail-safe cleanup of containers.
However, in a `DinD(Docker-in-Docker)` environment, the disable setting must be set.

I think this is what caused the error while working with GitHub actions.
A similar example is the Bitbucket pipeline, which is recommended to be turned off in the [official documentation](https://java.testcontainers.org/supported_docker_environment/continuous_integration/bitbucket_pipelines/). 