### PR TITLE
chore: upgrade image version to 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Testcontainers Meilisearch
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=testcontainers-meilisearch&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=testcontainers-meilisearch)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=testcontainers-meilisearch&metric=coverage)](https://sonarcloud.io/summary/new_code?id=testcontainers-meilisearch)
 ![](https://img.shields.io/github/license/junghoon-vans/testcontainers-meilisearch?label=License)
-![](https://img.shields.io/badge/meilisearch-1.2.0-blue)
+[![DockerHub](https://img.shields.io/badge/meilisearch-1.3.0-blue)](https://hub.docker.com/layers/getmeili/meilisearch/v1.3.0/images/sha256-f917749f925fe4107bca2473e7ed7405de5a18ad28caaf3e8cbd590f1eb27172?context=explore)
 
 A [Testcontainers](https://www.testcontainers.org/) implementation for [Meilisearch](https://www.meilisearch.com/).
 

--- a/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
+++ b/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
@@ -18,7 +18,7 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
 
   private static final int MEILISEARCH_DEFAULT_PORT = 7700;
   private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("getmeili/meilisearch");
-  private static final String DEFAULT_IMAGE_TAG = "v1.2.0";
+  private static final String DEFAULT_IMAGE_TAG = "v1.3.0";
 
   /**
    * Create a Meilisearch container with default settings


### PR DESCRIPTION
## Description

Upgraded the base image version to support [new features](https://github.com/meilisearch/meilisearch/releases/tag/v1.3.0) in meilisearch.
