### PR TITLE
refactor: remove default log consumer

### DIFF
--- a/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
+++ b/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
@@ -1,9 +1,6 @@
 package io.vanslog.testcontainers.meilisearch;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.utility.DockerImageName;
 
 /**
@@ -13,8 +10,6 @@ import org.testcontainers.utility.DockerImageName;
  * @author Junghoon Ban
  */
 public class MeilisearchContainer extends GenericContainer<MeilisearchContainer> {
-
-  Logger log = LoggerFactory.getLogger(MeilisearchContainer.class);
 
   private static final int MEILISEARCH_DEFAULT_PORT = 7700;
   private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("getmeili/meilisearch");
@@ -34,7 +29,6 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
   public MeilisearchContainer(DockerImageName dockerImageName) {
     super(dockerImageName);
     this.addExposedPort(MEILISEARCH_DEFAULT_PORT);
-    this.withLogConsumer(new Slf4jLogConsumer(log));
   }
 
   /**


### PR DESCRIPTION
## Related Issue

#24 

## Description

Removed the log consumer that was specified in the constructor.
