### PR TITLE
chore: Upgrade image version to v1.3.2

### DIFF
--- a/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
+++ b/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
@@ -13,7 +13,7 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
 
   private static final int MEILISEARCH_DEFAULT_PORT = 7700;
   private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("getmeili/meilisearch");
-  private static final String DEFAULT_IMAGE_TAG = "v1.3.0";
+  private static final String DEFAULT_IMAGE_TAG = "v1.3.2";
 
   /**
    * Create a Meilisearch container with default settings


### PR DESCRIPTION
## Related Issue

#27 

## Description

Set default image version to v1.3.2
