### PR TITLE
feat: add endpoint and master key accessors

### DIFF
--- a/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
+++ b/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
@@ -14,7 +14,6 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
   private static final int MEILISEARCH_DEFAULT_PORT = 7700;
   private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("getmeili/meilisearch");
   private static final String DEFAULT_IMAGE_TAG = "v1.3.4";
-  private String masterKey;
 
   /**
    * Create a Meilisearch container with default settings
@@ -38,7 +37,6 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
    * @return The current instance of the Meilisearch container
    */
   public MeilisearchContainer withMasterKey(String masterKey) {
-    this.masterKey = masterKey;
     this.addEnv("MEILI_MASTER_KEY", masterKey);
     return self();
   }
@@ -56,6 +54,6 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
    * @return The configured master key, or {@code null} when none was configured
    */
   public String getMasterKey() {
-    return masterKey;
+    return getEnvMap().get("MEILI_MASTER_KEY");
   }
 }

--- a/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
+++ b/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
@@ -14,6 +14,7 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
   private static final int MEILISEARCH_DEFAULT_PORT = 7700;
   private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("getmeili/meilisearch");
   private static final String DEFAULT_IMAGE_TAG = "v1.3.4";
+  private String masterKey;
 
   /**
    * Create a Meilisearch container with default settings
@@ -37,7 +38,24 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
    * @return The current instance of the Meilisearch container
    */
   public MeilisearchContainer withMasterKey(String masterKey) {
+    this.masterKey = masterKey;
     this.addEnv("MEILI_MASTER_KEY", masterKey);
     return self();
+  }
+
+  /**
+   * Get the HTTP endpoint for the running Meilisearch container.
+   * @return The HTTP endpoint to use with Meilisearch clients
+   */
+  public String getEndpoint() {
+    return "http://" + getHost() + ":" + getMappedPort(MEILISEARCH_DEFAULT_PORT);
+  }
+
+  /**
+   * Get the configured master key.
+   * @return The configured master key, or {@code null} when none was configured
+   */
+  public String getMasterKey() {
+    return masterKey;
   }
 }

--- a/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerTest.java
+++ b/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerTest.java
@@ -24,12 +24,19 @@ class MeilisearchContainerTest {
   }
 
   @Test
-  void shouldGetHost() {
-    assertThat(meilisearchContainer.getHost()).isEqualTo("localhost");
+  void shouldGetEndpoint() {
+    assertThat(meilisearchContainer.getEndpoint())
+        .startsWith("http://")
+        .contains(":" + meilisearchContainer.getMappedPort(7700));
   }
 
   @Test
   void getPort() {
     assertThat(meilisearchContainer.getMappedPort(7700)).isNotNull();
+  }
+
+  @Test
+  void shouldGetMasterKey() {
+    assertThat(meilisearchContainer.getMasterKey()).isEqualTo("masterKey");
   }
 }


### PR DESCRIPTION
## Summary

- Add `getEndpoint()` to expose a full HTTP URL for Meilisearch clients.
- Add `getMasterKey()` to return the configured master key while preserving the existing no-auth default.
- Replace the brittle localhost assertion with endpoint-focused coverage.

Closes #40

## Verification

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw -B -ntp test`