### PR TITLE
feat: add health wait and image compatibility

### DIFF
--- a/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
+++ b/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
@@ -1,6 +1,7 @@
 package io.vanslog.testcontainers.meilisearch;
 
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 /**
@@ -28,7 +29,11 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
    */
   public MeilisearchContainer(DockerImageName dockerImageName) {
     super(dockerImageName);
+    dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
     this.addExposedPort(MEILISEARCH_DEFAULT_PORT);
+    this.waitingFor(Wait.forHttp("/health")
+        .forPort(MEILISEARCH_DEFAULT_PORT)
+        .forStatusCode(200));
   }
 
   /**

--- a/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerTest.java
+++ b/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerTest.java
@@ -3,8 +3,10 @@ package io.vanslog.testcontainers.meilisearch;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Unit tests for {@link MeilisearchContainer}.
@@ -31,5 +33,13 @@ class MeilisearchContainerTest {
   @Test
   void getPort() {
     assertThat(meilisearchContainer.getMappedPort(7700)).isNotNull();
+  }
+
+  @Test
+  void shouldRejectIncompatibleImage() {
+    DockerImageName redisImage = DockerImageName.parse("redis:7");
+
+    assertThatThrownBy(() -> new MeilisearchContainer(redisImage))
+        .isInstanceOf(IllegalStateException.class);
   }
 }


### PR DESCRIPTION
## Summary

- Wait for the Meilisearch `/health` endpoint before marking the container ready.
- Assert custom images are compatible with `getmeili/meilisearch`.
- Add constructor coverage for rejecting incompatible images.

Closes #36

## Verification

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw -B -ntp test`