### PR TITLE
test: add Java SDK integration coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <!-- Dependencies -->
     <testcontainers>1.19.0</testcontainers>
+    <meilisearch-java>0.15.0</meilisearch-java>
     <junit-jupiter>5.10.0</junit-jupiter>
     <assertj-core>3.24.2</assertj-core>
     <logback>1.4.11</logback>
@@ -47,6 +48,12 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
       <version>${testcontainers}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.meilisearch.sdk</groupId>
+      <artifactId>meilisearch-java</artifactId>
+      <version>${meilisearch-java}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
+++ b/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
@@ -14,7 +14,6 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
   private static final int MEILISEARCH_DEFAULT_PORT = 7700;
   private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("getmeili/meilisearch");
   private static final String DEFAULT_IMAGE_TAG = "v1.3.4";
-  private String masterKey;
 
   /**
    * Create a Meilisearch container with default settings
@@ -38,7 +37,6 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
    * @return The current instance of the Meilisearch container
    */
   public MeilisearchContainer withMasterKey(String masterKey) {
-    this.masterKey = masterKey;
     this.addEnv("MEILI_MASTER_KEY", masterKey);
     return self();
   }
@@ -56,6 +54,6 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
    * @return The configured master key, or {@code null} when none was configured
    */
   public String getMasterKey() {
-    return masterKey;
+    return getEnvMap().get("MEILI_MASTER_KEY");
   }
 }

--- a/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
+++ b/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
@@ -14,6 +14,7 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
   private static final int MEILISEARCH_DEFAULT_PORT = 7700;
   private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("getmeili/meilisearch");
   private static final String DEFAULT_IMAGE_TAG = "v1.3.4";
+  private String masterKey;
 
   /**
    * Create a Meilisearch container with default settings
@@ -37,7 +38,24 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
    * @return The current instance of the Meilisearch container
    */
   public MeilisearchContainer withMasterKey(String masterKey) {
+    this.masterKey = masterKey;
     this.addEnv("MEILI_MASTER_KEY", masterKey);
     return self();
+  }
+
+  /**
+   * Get the HTTP endpoint for the running Meilisearch container.
+   * @return The HTTP endpoint to use with Meilisearch clients
+   */
+  public String getEndpoint() {
+    return "http://" + getHost() + ":" + getMappedPort(MEILISEARCH_DEFAULT_PORT);
+  }
+
+  /**
+   * Get the configured master key.
+   * @return The configured master key, or {@code null} when none was configured
+   */
+  public String getMasterKey() {
+    return masterKey;
   }
 }

--- a/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerJavaSdkTest.java
+++ b/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerJavaSdkTest.java
@@ -20,8 +20,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class MeilisearchContainerJavaSdkTest {
 
   @Container
-  private static final MeilisearchContainer meilisearchContainer = new MeilisearchContainer()
-      .withMasterKey("masterKey");
+  private static final MeilisearchContainer meilisearchContainer = createMeilisearchContainer();
+
+  @SuppressWarnings("resource")
+  private static MeilisearchContainer createMeilisearchContainer() {
+    return new MeilisearchContainer().withMasterKey("masterKey");
+  }
 
   @Test
   void shouldUseMeilisearchJavaSdk() throws Exception {

--- a/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerJavaSdkTest.java
+++ b/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerJavaSdkTest.java
@@ -1,0 +1,54 @@
+package io.vanslog.testcontainers.meilisearch;
+
+import com.meilisearch.sdk.Client;
+import com.meilisearch.sdk.Config;
+import com.meilisearch.sdk.Index;
+import com.meilisearch.sdk.model.SearchResult;
+import com.meilisearch.sdk.model.TaskInfo;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Java SDK integration tests for {@link MeilisearchContainer}.
+ *
+ * @author Junghoon Ban
+ */
+@Testcontainers
+class MeilisearchContainerJavaSdkTest {
+
+  @Container
+  private static final MeilisearchContainer meilisearchContainer = new MeilisearchContainer()
+      .withMasterKey("masterKey");
+
+  @Test
+  void shouldUseMeilisearchJavaSdk() throws Exception {
+    Client client = new Client(new Config(
+        meilisearchContainer.getEndpoint(),
+        meilisearchContainer.getMasterKey()));
+    String indexUid = "movies";
+    Index index = client.index(indexUid);
+
+    assertThat(client.isHealthy()).isTrue();
+
+    TaskInfo createIndexTask = client.createIndex(indexUid, "id");
+    index.waitForTask(createIndexTask.getTaskUid(), 15000, 100);
+
+    String documents = "["
+        + "{\"id\":1,\"title\":\"Dune\"},"
+        + "{\"id\":2,\"title\":\"Foundation\"}"
+        + "]";
+    TaskInfo addDocumentsTask = index.addDocuments(documents);
+    index.waitForTask(addDocumentsTask.getTaskUid(), 15000, 100);
+
+    SearchResult searchResult = index.search("dune");
+
+    assertThat(searchResult.getEstimatedTotalHits()).isEqualTo(1);
+    assertThat(searchResult.getHits())
+        .singleElement()
+        .extracting(hit -> hit.get("title"))
+        .isEqualTo("Dune");
+  }
+}

--- a/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerTest.java
+++ b/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerTest.java
@@ -24,12 +24,19 @@ class MeilisearchContainerTest {
   }
 
   @Test
-  void shouldGetHost() {
-    assertThat(meilisearchContainer.getHost()).isEqualTo("localhost");
+  void shouldGetEndpoint() {
+    assertThat(meilisearchContainer.getEndpoint())
+        .startsWith("http://")
+        .contains(":" + meilisearchContainer.getMappedPort(7700));
   }
 
   @Test
   void getPort() {
     assertThat(meilisearchContainer.getMappedPort(7700)).isNotNull();
+  }
+
+  @Test
+  void shouldGetMasterKey() {
+    assertThat(meilisearchContainer.getMasterKey()).isEqualTo("masterKey");
   }
 }


### PR DESCRIPTION
## Summary

- Add the official Meilisearch Java SDK as a test-scoped dependency.
- Exercise the container through SDK health, index creation, document indexing, task waiting, and search.
- Stack this on #42 so the test uses `getEndpoint()` and `getMasterKey()`.

Closes #37

## Verification

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw -B -ntp -Dtest=MeilisearchContainerJavaSdkTest test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw -B -ntp test`