### PR TITLE
feat: add no-analytics helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ MeilisearchContainer container = new MeilisearchContainer()
     .withMasterKey("masterKey");
 ```
 
+### Disable analytics
+
+```java
+@Container
+MeilisearchContainer container = new MeilisearchContainer()
+    .withNoAnalytics();
+```
+
 ### Java SDK client setup
 
 The container exposes helpers for the Meilisearch Java SDK:

--- a/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
+++ b/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
@@ -47,6 +47,16 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
     this.addEnv("MEILI_MASTER_KEY", masterKey);
     return self();
   }
+
+  /**
+   * Disable Meilisearch analytics for this container.
+   * @return The current instance of the Meilisearch container
+   */
+  public MeilisearchContainer withNoAnalytics() {
+    this.addEnv("MEILI_NO_ANALYTICS", "true");
+    return self();
+  }
+
   /**
    * Import a dump fixture from the test classpath when Meilisearch starts.
    * @param classpathResource The dump resource to import

--- a/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerTest.java
+++ b/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerTest.java
@@ -44,6 +44,13 @@ class MeilisearchContainerTest {
   }
 
   @Test
+  void shouldDisableAnalytics() {
+    try (MeilisearchContainer container = new MeilisearchContainer().withNoAnalytics()) {
+      assertThat(container.getEnvMap()).containsEntry("MEILI_NO_ANALYTICS", "true");
+    }
+  }
+
+  @Test
   void shouldRejectIncompatibleImage() {
     DockerImageName redisImage = DockerImageName.parse("redis:7");
 


### PR DESCRIPTION
## Summary
- Add `withNoAnalytics()` for disabling Meilisearch analytics in tests.
- Map the helper to the official `MEILI_NO_ANALYTICS=true` environment option.
- Document the helper in README usage examples.

## Verification
- `JAVA_HOME="$(/usr/libexec/java_home -v 21)" ./mvnw -B -ntp test`
- `JAVA_HOME="$(/usr/libexec/java_home -v 21)" ./mvnw -B -ntp verify`

Closes #54