### PR TITLE
feat: add database-exists import flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,25 @@ Snapshots are exact copies of Meilisearch data and must be created with the same
 Meilisearch version as the container image that imports them. Use dumps when you
 need a fixture that can move across Meilisearch versions.
 
+Dump and snapshot imports are strict by default. Add the matching helpers when
+you want Meilisearch to ignore missing import files or keep an existing database:
+
+```java
+@Container
+static MeilisearchContainer container = new MeilisearchContainer()
+    .withDumpImport("meilisearch/fixtures/movies.dump")
+    .withIgnoreMissingDump()
+    .withIgnoreDumpIfDbExists();
+```
+
+```java
+@Container
+static MeilisearchContainer container = new MeilisearchContainer()
+    .withSnapshotImport("meilisearch/fixtures/movies.snapshot")
+    .withIgnoreMissingSnapshot()
+    .withIgnoreSnapshotIfDbExists();
+```
+
 Setup
 ---
 

--- a/README.md
+++ b/README.md
@@ -116,13 +116,12 @@ need a fixture that can move across Meilisearch versions.
 Dump and snapshot imports are strict by default. Only one import source can be
 configured per container, and dump helpers only apply to dump imports while
 snapshot helpers only apply to snapshot imports. Add the matching helpers when
-you want Meilisearch to ignore missing import files or keep an existing database:
+you want Meilisearch to keep an existing database instead of importing a fixture:
 
 ```java
 @Container
 static MeilisearchContainer container = new MeilisearchContainer()
     .withDumpImport("meilisearch/fixtures/movies.dump")
-    .withIgnoreMissingDump()
     .withIgnoreDumpIfDbExists();
 ```
 
@@ -130,7 +129,6 @@ static MeilisearchContainer container = new MeilisearchContainer()
 @Container
 static MeilisearchContainer container = new MeilisearchContainer()
     .withSnapshotImport("meilisearch/fixtures/movies.snapshot")
-    .withIgnoreMissingSnapshot()
     .withIgnoreSnapshotIfDbExists();
 ```
 

--- a/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
+++ b/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
@@ -22,9 +22,7 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
   private static final String DEFAULT_IMAGE_TAG = "v1.43.0";
 
   private ImportType importType;
-  private boolean ignoreMissingDump;
   private boolean ignoreDumpIfDbExists;
-  private boolean ignoreMissingSnapshot;
   private boolean ignoreSnapshotIfDbExists;
 
   private enum ImportType {
@@ -135,17 +133,6 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
   }
 
   /**
-   * Start normally when the configured dump fixture is missing.
-   * @return The current instance of the Meilisearch container
-   */
-  public MeilisearchContainer withIgnoreMissingDump() {
-    assertImportTypeCompatible(ImportType.DUMP);
-    this.ignoreMissingDump = true;
-    configureImportCommand();
-    return self();
-  }
-
-  /**
    * Start with the existing database when a dump fixture is configured and data already exists.
    * @return The current instance of the Meilisearch container
    */
@@ -178,17 +165,6 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
   }
 
   /**
-   * Start normally when the configured snapshot fixture is missing.
-   * @return The current instance of the Meilisearch container
-   */
-  public MeilisearchContainer withIgnoreMissingSnapshot() {
-    assertImportTypeCompatible(ImportType.SNAPSHOT);
-    this.ignoreMissingSnapshot = true;
-    configureImportCommand();
-    return self();
-  }
-
-  /**
    * Start with the existing database when a snapshot fixture is configured and data already exists.
    * @return The current instance of the Meilisearch container
    */
@@ -215,9 +191,9 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
 
   private boolean hasFlagsForDifferentImportType(ImportType importType) {
     if (importType == ImportType.DUMP) {
-      return ignoreMissingSnapshot || ignoreSnapshotIfDbExists;
+      return ignoreSnapshotIfDbExists;
     }
-    return ignoreMissingDump || ignoreDumpIfDbExists;
+    return ignoreDumpIfDbExists;
   }
 
   private void configureImportCommand() {
@@ -230,12 +206,10 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
     if (importType == ImportType.DUMP) {
       command.add("--import-dump");
       command.add(DUMP_IMPORT_PATH);
-      addFlag(command, ignoreMissingDump, "--ignore-missing-dump");
       addFlag(command, ignoreDumpIfDbExists, "--ignore-dump-if-db-exists");
     } else {
       command.add("--import-snapshot");
       command.add(SNAPSHOT_IMPORT_PATH);
-      addFlag(command, ignoreMissingSnapshot, "--ignore-missing-snapshot");
       addFlag(command, ignoreSnapshotIfDbExists, "--ignore-snapshot-if-db-exists");
     }
     this.withCommand(command.toArray(new String[0]));

--- a/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
+++ b/src/main/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainer.java
@@ -1,5 +1,7 @@
 package io.vanslog.testcontainers.meilisearch;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
@@ -18,6 +20,17 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
   private static final String SNAPSHOT_IMPORT_PATH = importPath("snapshots", "import.snapshot");
   private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("getmeili/meilisearch");
   private static final String DEFAULT_IMAGE_TAG = "v1.43.0";
+
+  private ImportType importType;
+  private boolean ignoreMissingDump;
+  private boolean ignoreDumpIfDbExists;
+  private boolean ignoreMissingSnapshot;
+  private boolean ignoreSnapshotIfDbExists;
+
+  private enum ImportType {
+    DUMP,
+    SNAPSHOT
+  }
 
   private static String importPath(String directory, String fileName) {
     return String.join("/", "", "meili_data", directory, fileName);
@@ -78,7 +91,28 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
    */
   public MeilisearchContainer withDumpImport(MountableFile dumpFile) {
     this.withCopyFileToContainer(dumpFile, DUMP_IMPORT_PATH);
-    this.withCommand("meilisearch", "--import-dump", DUMP_IMPORT_PATH);
+    this.importType = ImportType.DUMP;
+    configureImportCommand();
+    return self();
+  }
+
+  /**
+   * Start normally when the configured dump fixture is missing.
+   * @return The current instance of the Meilisearch container
+   */
+  public MeilisearchContainer withIgnoreMissingDump() {
+    this.ignoreMissingDump = true;
+    configureImportCommand();
+    return self();
+  }
+
+  /**
+   * Start with the existing database when a dump fixture is configured and data already exists.
+   * @return The current instance of the Meilisearch container
+   */
+  public MeilisearchContainer withIgnoreDumpIfDbExists() {
+    this.ignoreDumpIfDbExists = true;
+    configureImportCommand();
     return self();
   }
 
@@ -98,8 +132,56 @@ public class MeilisearchContainer extends GenericContainer<MeilisearchContainer>
    */
   public MeilisearchContainer withSnapshotImport(MountableFile snapshotFile) {
     this.withCopyFileToContainer(snapshotFile, SNAPSHOT_IMPORT_PATH);
-    this.withCommand("meilisearch", "--import-snapshot", SNAPSHOT_IMPORT_PATH);
+    this.importType = ImportType.SNAPSHOT;
+    configureImportCommand();
     return self();
+  }
+
+  /**
+   * Start normally when the configured snapshot fixture is missing.
+   * @return The current instance of the Meilisearch container
+   */
+  public MeilisearchContainer withIgnoreMissingSnapshot() {
+    this.ignoreMissingSnapshot = true;
+    configureImportCommand();
+    return self();
+  }
+
+  /**
+   * Start with the existing database when a snapshot fixture is configured and data already exists.
+   * @return The current instance of the Meilisearch container
+   */
+  public MeilisearchContainer withIgnoreSnapshotIfDbExists() {
+    this.ignoreSnapshotIfDbExists = true;
+    configureImportCommand();
+    return self();
+  }
+
+  private void configureImportCommand() {
+    if (importType == null) {
+      return;
+    }
+
+    List<String> command = new ArrayList<>();
+    command.add("meilisearch");
+    if (importType == ImportType.DUMP) {
+      command.add("--import-dump");
+      command.add(DUMP_IMPORT_PATH);
+      addFlag(command, ignoreMissingDump, "--ignore-missing-dump");
+      addFlag(command, ignoreDumpIfDbExists, "--ignore-dump-if-db-exists");
+    } else {
+      command.add("--import-snapshot");
+      command.add(SNAPSHOT_IMPORT_PATH);
+      addFlag(command, ignoreMissingSnapshot, "--ignore-missing-snapshot");
+      addFlag(command, ignoreSnapshotIfDbExists, "--ignore-snapshot-if-db-exists");
+    }
+    this.withCommand(command.toArray(new String[0]));
+  }
+
+  private static void addFlag(List<String> command, boolean enabled, String flag) {
+    if (enabled) {
+      command.add(flag);
+    }
   }
 
   /**

--- a/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerDumpImportTest.java
+++ b/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerDumpImportTest.java
@@ -2,8 +2,13 @@ package io.vanslog.testcontainers.meilisearch;
 
 import com.meilisearch.sdk.Client;
 import com.meilisearch.sdk.Config;
+import com.meilisearch.sdk.Index;
 import com.meilisearch.sdk.model.SearchResult;
+import com.meilisearch.sdk.model.TaskInfo;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -68,6 +73,61 @@ class MeilisearchContainerDumpImportTest {
           .singleElement()
           .extracting(hit -> hit.get("title"))
           .isEqualTo("Dune");
+    } finally {
+      container.close();
+    }
+  }
+
+  @Test
+  void shouldIgnoreDumpImportWhenDatabaseExists(@TempDir Path dataDirectory) throws Exception {
+    seedExistingDatabase(dataDirectory);
+
+    MeilisearchContainer container = new MeilisearchContainer();
+    try {
+      container
+          .withFileSystemBind(dataDirectory.toString(), "/meili_data", BindMode.READ_WRITE)
+          .withMasterKey("masterKey")
+          .withDumpImport("meilisearch/fixtures/movies.dump")
+          .withIgnoreDumpIfDbExists();
+      container.start();
+
+      Client client = new Client(new Config(
+          container.getEndpoint(),
+          container.getMasterKey()));
+
+      assertThat(client.isHealthy()).isTrue();
+
+      SearchResult searchResult = client.index("existing_movies").search("arrival");
+
+      assertThat(searchResult.getEstimatedTotalHits()).isEqualTo(1);
+      assertThat(searchResult.getHits())
+          .singleElement()
+          .extracting(hit -> hit.get("title"))
+          .isEqualTo("Arrival");
+    } finally {
+      container.close();
+    }
+  }
+
+  private static void seedExistingDatabase(Path dataDirectory) throws Exception {
+    MeilisearchContainer container = new MeilisearchContainer();
+    try {
+      container
+          .withFileSystemBind(dataDirectory.toString(), "/meili_data", BindMode.READ_WRITE)
+          .withMasterKey("masterKey");
+      container.start();
+
+      Client client = new Client(new Config(
+          container.getEndpoint(),
+          container.getMasterKey()));
+      String indexUid = "existing_movies";
+      Index index = client.index(indexUid);
+
+      TaskInfo createIndexTask = client.createIndex(indexUid, "id");
+      index.waitForTask(createIndexTask.getTaskUid(), 15000, 100);
+
+      TaskInfo addDocumentsTask = index.addDocuments("[{\"id\":1,\"title\":\"Arrival\"}]");
+      index.waitForTask(addDocumentsTask.getTaskUid(), 15000, 100);
     } finally {
       container.close();
     }

--- a/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerDumpImportTest.java
+++ b/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerDumpImportTest.java
@@ -50,13 +50,12 @@ class MeilisearchContainerDumpImportTest {
   }
 
   @Test
-  void shouldImportDumpFixtureWithIgnoreFlags() throws Exception {
+  void shouldImportDumpFixtureWithIgnoreDatabaseExistsFlag() throws Exception {
     MeilisearchContainer container = new MeilisearchContainer();
     try {
       container
           .withMasterKey("masterKey")
           .withDumpImport("meilisearch/fixtures/movies.dump")
-          .withIgnoreMissingDump()
           .withIgnoreDumpIfDbExists();
       container.start();
 

--- a/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerDumpImportTest.java
+++ b/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerDumpImportTest.java
@@ -43,4 +43,33 @@ class MeilisearchContainerDumpImportTest {
         .extracting(hit -> hit.get("title"))
         .isEqualTo("Dune");
   }
+
+  @Test
+  void shouldImportDumpFixtureWithIgnoreFlags() throws Exception {
+    MeilisearchContainer container = new MeilisearchContainer();
+    try {
+      container
+          .withMasterKey("masterKey")
+          .withDumpImport("meilisearch/fixtures/movies.dump")
+          .withIgnoreMissingDump()
+          .withIgnoreDumpIfDbExists();
+      container.start();
+
+      Client client = new Client(new Config(
+          container.getEndpoint(),
+          container.getMasterKey()));
+
+      assertThat(client.isHealthy()).isTrue();
+
+      SearchResult searchResult = client.index("movies").search("dune");
+
+      assertThat(searchResult.getEstimatedTotalHits()).isEqualTo(1);
+      assertThat(searchResult.getHits())
+          .singleElement()
+          .extracting(hit -> hit.get("title"))
+          .isEqualTo("Dune");
+    } finally {
+      container.close();
+    }
+  }
 }

--- a/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerDumpImportTest.java
+++ b/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerDumpImportTest.java
@@ -5,10 +5,10 @@ import com.meilisearch.sdk.Config;
 import com.meilisearch.sdk.Index;
 import com.meilisearch.sdk.model.SearchResult;
 import com.meilisearch.sdk.model.TaskInfo;
-import java.nio.file.Path;
+import com.github.dockerjava.api.model.Bind;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.testcontainers.containers.BindMode;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -79,13 +79,13 @@ class MeilisearchContainerDumpImportTest {
   }
 
   @Test
-  void shouldIgnoreDumpImportWhenDatabaseExists(@TempDir Path dataDirectory) throws Exception {
-    seedExistingDatabase(dataDirectory);
+  void shouldIgnoreDumpImportWhenDatabaseExists() throws Exception {
+    String volumeName = newVolumeName();
+    seedExistingDatabase(volumeName);
 
     MeilisearchContainer container = new MeilisearchContainer();
     try {
-      container
-          .withFileSystemBind(dataDirectory.toString(), "/meili_data", BindMode.READ_WRITE)
+      withDataVolume(container, volumeName)
           .withMasterKey("masterKey")
           .withDumpImport("meilisearch/fixtures/movies.dump")
           .withIgnoreDumpIfDbExists();
@@ -106,14 +106,14 @@ class MeilisearchContainerDumpImportTest {
           .isEqualTo("Arrival");
     } finally {
       container.close();
+      removeVolume(volumeName);
     }
   }
 
-  private static void seedExistingDatabase(Path dataDirectory) throws Exception {
+  private static void seedExistingDatabase(String volumeName) throws Exception {
     MeilisearchContainer container = new MeilisearchContainer();
     try {
-      container
-          .withFileSystemBind(dataDirectory.toString(), "/meili_data", BindMode.READ_WRITE)
+      withDataVolume(container, volumeName)
           .withMasterKey("masterKey");
       container.start();
 
@@ -131,5 +131,19 @@ class MeilisearchContainerDumpImportTest {
     } finally {
       container.close();
     }
+  }
+
+  private static MeilisearchContainer withDataVolume(MeilisearchContainer container, String volumeName) {
+    return container.withCreateContainerCmdModifier(command -> command
+        .getHostConfig()
+        .withBinds(Bind.parse(volumeName + ":/meili_data")));
+  }
+
+  private static String newVolumeName() {
+    return "testcontainers-meilisearch-" + UUID.randomUUID();
+  }
+
+  private static void removeVolume(String volumeName) {
+    DockerClientFactory.instance().client().removeVolumeCmd(volumeName).exec();
   }
 }

--- a/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerSnapshotImportTest.java
+++ b/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerSnapshotImportTest.java
@@ -2,8 +2,13 @@ package io.vanslog.testcontainers.meilisearch;
 
 import com.meilisearch.sdk.Client;
 import com.meilisearch.sdk.Config;
+import com.meilisearch.sdk.Index;
 import com.meilisearch.sdk.model.SearchResult;
+import com.meilisearch.sdk.model.TaskInfo;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -68,6 +73,61 @@ class MeilisearchContainerSnapshotImportTest {
           .singleElement()
           .extracting(hit -> hit.get("title"))
           .isEqualTo("Dune");
+    } finally {
+      container.close();
+    }
+  }
+
+  @Test
+  void shouldIgnoreSnapshotImportWhenDatabaseExists(@TempDir Path dataDirectory) throws Exception {
+    seedExistingDatabase(dataDirectory);
+
+    MeilisearchContainer container = new MeilisearchContainer();
+    try {
+      container
+          .withFileSystemBind(dataDirectory.toString(), "/meili_data", BindMode.READ_WRITE)
+          .withMasterKey("masterKey")
+          .withSnapshotImport("meilisearch/fixtures/movies.snapshot")
+          .withIgnoreSnapshotIfDbExists();
+      container.start();
+
+      Client client = new Client(new Config(
+          container.getEndpoint(),
+          container.getMasterKey()));
+
+      assertThat(client.isHealthy()).isTrue();
+
+      SearchResult searchResult = client.index("existing_movies").search("arrival");
+
+      assertThat(searchResult.getEstimatedTotalHits()).isEqualTo(1);
+      assertThat(searchResult.getHits())
+          .singleElement()
+          .extracting(hit -> hit.get("title"))
+          .isEqualTo("Arrival");
+    } finally {
+      container.close();
+    }
+  }
+
+  private static void seedExistingDatabase(Path dataDirectory) throws Exception {
+    MeilisearchContainer container = new MeilisearchContainer();
+    try {
+      container
+          .withFileSystemBind(dataDirectory.toString(), "/meili_data", BindMode.READ_WRITE)
+          .withMasterKey("masterKey");
+      container.start();
+
+      Client client = new Client(new Config(
+          container.getEndpoint(),
+          container.getMasterKey()));
+      String indexUid = "existing_movies";
+      Index index = client.index(indexUid);
+
+      TaskInfo createIndexTask = client.createIndex(indexUid, "id");
+      index.waitForTask(createIndexTask.getTaskUid(), 15000, 100);
+
+      TaskInfo addDocumentsTask = index.addDocuments("[{\"id\":1,\"title\":\"Arrival\"}]");
+      index.waitForTask(addDocumentsTask.getTaskUid(), 15000, 100);
     } finally {
       container.close();
     }

--- a/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerSnapshotImportTest.java
+++ b/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerSnapshotImportTest.java
@@ -5,10 +5,10 @@ import com.meilisearch.sdk.Config;
 import com.meilisearch.sdk.Index;
 import com.meilisearch.sdk.model.SearchResult;
 import com.meilisearch.sdk.model.TaskInfo;
-import java.nio.file.Path;
+import com.github.dockerjava.api.model.Bind;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.testcontainers.containers.BindMode;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -79,13 +79,13 @@ class MeilisearchContainerSnapshotImportTest {
   }
 
   @Test
-  void shouldIgnoreSnapshotImportWhenDatabaseExists(@TempDir Path dataDirectory) throws Exception {
-    seedExistingDatabase(dataDirectory);
+  void shouldIgnoreSnapshotImportWhenDatabaseExists() throws Exception {
+    String volumeName = newVolumeName();
+    seedExistingDatabase(volumeName);
 
     MeilisearchContainer container = new MeilisearchContainer();
     try {
-      container
-          .withFileSystemBind(dataDirectory.toString(), "/meili_data", BindMode.READ_WRITE)
+      withDataVolume(container, volumeName)
           .withMasterKey("masterKey")
           .withSnapshotImport("meilisearch/fixtures/movies.snapshot")
           .withIgnoreSnapshotIfDbExists();
@@ -106,14 +106,14 @@ class MeilisearchContainerSnapshotImportTest {
           .isEqualTo("Arrival");
     } finally {
       container.close();
+      removeVolume(volumeName);
     }
   }
 
-  private static void seedExistingDatabase(Path dataDirectory) throws Exception {
+  private static void seedExistingDatabase(String volumeName) throws Exception {
     MeilisearchContainer container = new MeilisearchContainer();
     try {
-      container
-          .withFileSystemBind(dataDirectory.toString(), "/meili_data", BindMode.READ_WRITE)
+      withDataVolume(container, volumeName)
           .withMasterKey("masterKey");
       container.start();
 
@@ -131,5 +131,19 @@ class MeilisearchContainerSnapshotImportTest {
     } finally {
       container.close();
     }
+  }
+
+  private static MeilisearchContainer withDataVolume(MeilisearchContainer container, String volumeName) {
+    return container.withCreateContainerCmdModifier(command -> command
+        .getHostConfig()
+        .withBinds(Bind.parse(volumeName + ":/meili_data")));
+  }
+
+  private static String newVolumeName() {
+    return "testcontainers-meilisearch-" + UUID.randomUUID();
+  }
+
+  private static void removeVolume(String volumeName) {
+    DockerClientFactory.instance().client().removeVolumeCmd(volumeName).exec();
   }
 }

--- a/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerSnapshotImportTest.java
+++ b/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerSnapshotImportTest.java
@@ -43,4 +43,33 @@ class MeilisearchContainerSnapshotImportTest {
         .extracting(hit -> hit.get("title"))
         .isEqualTo("Dune");
   }
+
+  @Test
+  void shouldImportSnapshotFixtureWithIgnoreFlags() throws Exception {
+    MeilisearchContainer container = new MeilisearchContainer();
+    try {
+      container
+          .withMasterKey("masterKey")
+          .withSnapshotImport("meilisearch/fixtures/movies.snapshot")
+          .withIgnoreMissingSnapshot()
+          .withIgnoreSnapshotIfDbExists();
+      container.start();
+
+      Client client = new Client(new Config(
+          container.getEndpoint(),
+          container.getMasterKey()));
+
+      assertThat(client.isHealthy()).isTrue();
+
+      SearchResult searchResult = client.index("movies").search("dune");
+
+      assertThat(searchResult.getEstimatedTotalHits()).isEqualTo(1);
+      assertThat(searchResult.getHits())
+          .singleElement()
+          .extracting(hit -> hit.get("title"))
+          .isEqualTo("Dune");
+    } finally {
+      container.close();
+    }
+  }
 }

--- a/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerSnapshotImportTest.java
+++ b/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerSnapshotImportTest.java
@@ -50,13 +50,12 @@ class MeilisearchContainerSnapshotImportTest {
   }
 
   @Test
-  void shouldImportSnapshotFixtureWithIgnoreFlags() throws Exception {
+  void shouldImportSnapshotFixtureWithIgnoreDatabaseExistsFlag() throws Exception {
     MeilisearchContainer container = new MeilisearchContainer();
     try {
       container
           .withMasterKey("masterKey")
           .withSnapshotImport("meilisearch/fixtures/movies.snapshot")
-          .withIgnoreMissingSnapshot()
           .withIgnoreSnapshotIfDbExists();
       container.start();
 

--- a/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerTest.java
+++ b/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerTest.java
@@ -49,18 +49,17 @@ class MeilisearchContainerTest {
         .withDumpImport("meilisearch/fixtures/movies.dump")) {
       assertThat(container.getCommandParts())
           .contains("--import-dump")
-          .doesNotContain("--ignore-missing-dump", "--ignore-dump-if-db-exists");
+          .doesNotContain("--ignore-dump-if-db-exists");
     }
   }
 
   @Test
-  void shouldConfigureDumpImportFlags() {
+  void shouldConfigureDumpImportIfDatabaseExistsFlag() {
     try (MeilisearchContainer container = new MeilisearchContainer()
         .withDumpImport("meilisearch/fixtures/movies.dump")
-        .withIgnoreMissingDump()
         .withIgnoreDumpIfDbExists()) {
       assertThat(container.getCommandParts())
-          .contains("--import-dump", "--ignore-missing-dump", "--ignore-dump-if-db-exists");
+          .contains("--import-dump", "--ignore-dump-if-db-exists");
     }
   }
 
@@ -70,18 +69,17 @@ class MeilisearchContainerTest {
         .withSnapshotImport("meilisearch/fixtures/movies.snapshot")) {
       assertThat(container.getCommandParts())
           .contains("--import-snapshot")
-          .doesNotContain("--ignore-missing-snapshot", "--ignore-snapshot-if-db-exists");
+          .doesNotContain("--ignore-snapshot-if-db-exists");
     }
   }
 
   @Test
-  void shouldConfigureSnapshotImportFlags() {
+  void shouldConfigureSnapshotImportIfDatabaseExistsFlag() {
     try (MeilisearchContainer container = new MeilisearchContainer()
-        .withIgnoreMissingSnapshot()
         .withIgnoreSnapshotIfDbExists()
         .withSnapshotImport("meilisearch/fixtures/movies.snapshot")) {
       assertThat(container.getCommandParts())
-          .contains("--import-snapshot", "--ignore-missing-snapshot", "--ignore-snapshot-if-db-exists");
+          .contains("--import-snapshot", "--ignore-snapshot-if-db-exists");
     }
   }
 
@@ -132,12 +130,12 @@ class MeilisearchContainerTest {
 
   @Test
   void shouldRejectImportFlagsForDifferentImportType() {
-    try (MeilisearchContainer container = new MeilisearchContainer().withIgnoreMissingDump()) {
+    try (MeilisearchContainer container = new MeilisearchContainer().withIgnoreDumpIfDbExists()) {
       assertThatThrownBy(() -> container.withSnapshotImport("meilisearch/fixtures/movies.snapshot"))
           .isInstanceOf(IllegalStateException.class);
     }
 
-    try (MeilisearchContainer container = new MeilisearchContainer().withIgnoreMissingSnapshot()) {
+    try (MeilisearchContainer container = new MeilisearchContainer().withIgnoreSnapshotIfDbExists()) {
       assertThatThrownBy(() -> container.withDumpImport("meilisearch/fixtures/movies.dump"))
           .isInstanceOf(IllegalStateException.class);
     }

--- a/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerTest.java
+++ b/src/test/java/io/vanslog/testcontainers/meilisearch/MeilisearchContainerTest.java
@@ -44,6 +44,48 @@ class MeilisearchContainerTest {
   }
 
   @Test
+  void shouldKeepDumpImportStrictByDefault() {
+    try (MeilisearchContainer container = new MeilisearchContainer()
+        .withDumpImport("meilisearch/fixtures/movies.dump")) {
+      assertThat(container.getCommandParts())
+          .contains("--import-dump")
+          .doesNotContain("--ignore-missing-dump", "--ignore-dump-if-db-exists");
+    }
+  }
+
+  @Test
+  void shouldConfigureDumpImportFlags() {
+    try (MeilisearchContainer container = new MeilisearchContainer()
+        .withDumpImport("meilisearch/fixtures/movies.dump")
+        .withIgnoreMissingDump()
+        .withIgnoreDumpIfDbExists()) {
+      assertThat(container.getCommandParts())
+          .contains("--import-dump", "--ignore-missing-dump", "--ignore-dump-if-db-exists");
+    }
+  }
+
+  @Test
+  void shouldKeepSnapshotImportStrictByDefault() {
+    try (MeilisearchContainer container = new MeilisearchContainer()
+        .withSnapshotImport("meilisearch/fixtures/movies.snapshot")) {
+      assertThat(container.getCommandParts())
+          .contains("--import-snapshot")
+          .doesNotContain("--ignore-missing-snapshot", "--ignore-snapshot-if-db-exists");
+    }
+  }
+
+  @Test
+  void shouldConfigureSnapshotImportFlags() {
+    try (MeilisearchContainer container = new MeilisearchContainer()
+        .withIgnoreMissingSnapshot()
+        .withIgnoreSnapshotIfDbExists()
+        .withSnapshotImport("meilisearch/fixtures/movies.snapshot")) {
+      assertThat(container.getCommandParts())
+          .contains("--import-snapshot", "--ignore-missing-snapshot", "--ignore-snapshot-if-db-exists");
+    }
+  }
+
+  @Test
   void shouldDisableAnalytics() {
     try (MeilisearchContainer container = new MeilisearchContainer().withNoAnalytics()) {
       assertThat(container.getEnvMap()).containsEntry("MEILI_NO_ANALYTICS", "true");


### PR DESCRIPTION
## Summary
- Add opt-in dump and snapshot helpers for keeping an existing Meilisearch database when an import fixture is configured.
- Keep dump and snapshot imports strict by default and reject mixed import type configuration.
- Cover command generation and real existing-database behavior with Docker volume integration tests.

## Verification
- `JAVA_HOME="$(/usr/libexec/java_home -v 21)" ./mvnw -B -ntp -Dtest=MeilisearchContainerTest,MeilisearchContainerDumpImportTest,MeilisearchContainerSnapshotImportTest test`
- `JAVA_HOME="$(/usr/libexec/java_home -v 21)" ./mvnw -B -ntp clean verify`

Closes #51