### PR TITLE
docs: add Spring and JUnit examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,46 @@ The container exposes helpers for the Meilisearch Java SDK:
 Client client = new Client(new Config(container.getEndpoint(), container.getMasterKey()));
 ```
 
+### JUnit 5 integration
+
+```java
+@Testcontainers
+class SearchTest {
+
+    @Container
+    static MeilisearchContainer container = new MeilisearchContainer()
+        .withMasterKey("masterKey");
+
+    @Test
+    void connectsWithSdk() {
+        Client client = new Client(new Config(container.getEndpoint(), container.getMasterKey()));
+    }
+}
+```
+
+### Spring Boot integration
+
+For Spring Boot tests, register your own application properties from the container.
+Spring Boot 3.1+ can also wire custom containers through its Testcontainers
+support if you prefer.
+
+```java
+@Testcontainers
+@SpringBootTest
+class SearchIntegrationTest {
+
+    @Container
+    static MeilisearchContainer container = new MeilisearchContainer()
+        .withMasterKey("masterKey");
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("app.search.endpoint", container::getEndpoint);
+        registry.add("app.search.api-key", container::getMasterKey);
+    }
+}
+```
+
 ### Index documents and wait for tasks
 
 ```java


### PR DESCRIPTION
## Summary
- Add a plain JUnit 5 integration example using `@Testcontainers` and `@Container`.
- Add a Spring Boot example that wires Meilisearch properties with `@DynamicPropertySource`.
- Note Spring Boot 3.1+ Testcontainers support while keeping the example broadly compatible.

## Verification
- `JAVA_HOME="$(/usr/libexec/java_home -v 21)" ./mvnw -B -ntp verify`

Closes #57