### PR TITLE
docs: add development and release guides

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,48 @@
+# Development
+
+This project is a Java 11-compatible Testcontainers module for Meilisearch.
+
+## Requirements
+
+- JDK 17 or newer for local builds and CI parity
+- Docker, because tests start real Meilisearch containers through Testcontainers
+- Maven Wrapper from this repository (`./mvnw`)
+
+## Branches
+
+- `1.x` is the maintenance lane for Testcontainers 1.x releases and `v1.*` tags.
+- `main` is the active lane for Testcontainers 2.x releases and `v2.*` tags.
+- Shared changes should land on `1.x` first when they apply to both lanes, then be ported to `main`.
+
+## Local Verification
+
+Run the full verification before opening or updating a pull request:
+
+```bash
+./mvnw -B -ntp verify
+```
+
+The CI workflow runs verification with the `coverage` profile:
+
+```bash
+./mvnw -B -ntp verify -Pcoverage
+```
+
+Use a valid local JDK explicitly if your shell points to a stale Java installation:
+
+```bash
+JAVA_HOME="$(/usr/libexec/java_home -v 21)" ./mvnw -B -ntp verify
+```
+
+## Test Notes
+
+- Unit and integration tests use JUnit 5.
+- Testcontainers tests require Docker to be available.
+- Fixture import tests use resources under `src/test/resources/meilisearch/fixtures`.
+- Snapshot fixtures must be created with the same Meilisearch image version used by the container.
+
+## Pull Requests
+
+- Keep each pull request scoped to one issue or release chore.
+- Pair public API changes with tests and README examples.
+- Target `1.x` for `v1.*` work and `main` for `v2.*` work.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,18 @@ If you use the Meilisearch Java SDK in tests on Java 17 or later, add:
 </dependency>
 ```
 
+Development
+---
+
+See [DEVELOPMENT.md](DEVELOPMENT.md) for local setup, verification commands,
+branch lanes, and Testcontainers testing notes.
+
+Releasing
+---
+
+See [RELEASING.md](RELEASING.md) for stable release, snapshot deployment, and
+post-release version bump steps.
+
 Release lanes
 ---
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,59 @@
+# Releasing
+
+This repository publishes separate release lanes for Testcontainers compatibility.
+
+## Release Lanes
+
+| Branch | Release tags | Purpose |
+| --- | --- | --- |
+| `1.x` | `v1.*` | Maintenance line for Testcontainers 1.x |
+| `main` | `v2.*` | Active line for Testcontainers 2.x |
+
+Stable releases are deployed when a GitHub Release is published. Snapshot deployments run from pushes to `main` and `1.x` only when the Maven project version ends with `-SNAPSHOT`.
+
+## Before a Stable Release
+
+1. Ensure all release-scope pull requests are merged into the target branch.
+2. Ensure the milestone has no open issues, or move intentionally deferred issues out of the milestone.
+3. Run final verification on the target branch:
+
+```bash
+./mvnw -B -ntp verify
+```
+
+4. Open a release pull request against the target branch:
+   - Set `pom.xml` to the release version, for example `1.2.0`.
+   - Update README dependency snippets to the same release version.
+   - Keep README snippets on the latest stable version after release.
+5. Merge the release pull request after CI passes.
+
+## Publishing
+
+1. Create and publish a GitHub Release tag from the target branch.
+2. Use tag format `v<version>`, for example `v1.2.0`.
+3. The release workflow validates the tag lane:
+   - `v1.*` tags must be contained in `1.x`.
+   - `v2.*` tags must be contained in `main`.
+4. The release workflow sets the Maven version from the tag, verifies the build, and deploys to Central Publishing.
+
+## After a Stable Release
+
+1. Open a post-release pull request against the release branch.
+2. Bump `pom.xml` to the next snapshot version, for example `1.2.1-SNAPSHOT`.
+3. Leave README dependency snippets on the released stable version.
+4. Merge after CI passes.
+
+## Required Repository Secrets
+
+Central Publishing requires these repository secrets:
+
+- `CENTRAL_USERNAME`
+- `CENTRAL_TOKEN`
+- `GPG_PRIVATE_KEY`
+- `GPG_PASSPHRASE`
+
+## Documentation Site
+
+This repository currently has no separate documentation site or documentation deployment workflow. Public documentation lives in `README.md` and Javadocs published with release artifacts.
+
+If a standalone documentation site is added later, add the site build and deployment steps before documenting a docs deployment process here.


### PR DESCRIPTION
## Summary
- Add `DEVELOPMENT.md` with local verification, branch lane, and Testcontainers testing notes.
- Add `RELEASING.md` with stable release, snapshot deployment, and post-release bump steps.
- Link both guides from the README and note that no standalone docs site exists yet.

## Verification
- `JAVA_HOME="$(/usr/libexec/java_home -v 21)" ./mvnw -B -ntp verify`