### PR TITLE
release: v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,64 +12,8 @@ A [Testcontainers](https://www.testcontainers.org/) implementation for [Meilisea
 How to use
 ---
 
-Use the `@Container` annotation to start a Meilisearch container in your tests.
-
-### Default image
-
-```java
-@Container
-MeilisearchContainer container = new MeilisearchContainer();
-```
-
-### Custom image
-
-```java
-@Container
-MeilisearchContainer container = new MeilisearchContainer(
-    DockerImageName.parse("getmeili/meilisearch:v1.43.0"));
-```
-
-### Configure master key
-
-```java
-@Container
-MeilisearchContainer container = new MeilisearchContainer()
-    .withMasterKey("masterKey");
-```
-
-### Configure environment mode
-
-```java
-@Container
-MeilisearchContainer container = new MeilisearchContainer()
-    .withEnvMode(MeilisearchEnvMode.DEVELOPMENT);
-```
-
-### Configure log level
-
-```java
-@Container
-MeilisearchContainer container = new MeilisearchContainer()
-    .withLogLevel(MeilisearchLogLevel.DEBUG);
-```
-
-### Disable analytics
-
-```java
-@Container
-MeilisearchContainer container = new MeilisearchContainer()
-    .withNoAnalytics();
-```
-
-### Java SDK client setup
-
-The container exposes helpers for the Meilisearch Java SDK:
-
-```java
-Client client = new Client(new Config(container.getEndpoint(), container.getMasterKey()));
-```
-
-### JUnit 5 integration
+Use the `@Container` annotation to start a Meilisearch container in your tests,
+then connect clients with the container endpoint and master key.
 
 ```java
 @Testcontainers
@@ -86,91 +30,11 @@ class SearchTest {
 }
 ```
 
-### Spring Boot integration
+The container supports custom images, master keys, environment modes, log levels,
+analytics opt-out, Java SDK client helpers, Spring Boot property wiring, dump
+imports, snapshot imports, and existing-database import flags.
 
-For Spring Boot tests, register your own application properties from the container.
-Spring Boot 3.1+ can also wire custom containers through its Testcontainers
-support if you prefer.
-
-```java
-@Testcontainers
-@SpringBootTest
-class SearchIntegrationTest {
-
-    @Container
-    static MeilisearchContainer container = new MeilisearchContainer()
-        .withMasterKey("masterKey");
-
-    @DynamicPropertySource
-    static void registerProperties(DynamicPropertyRegistry registry) {
-        registry.add("app.search.endpoint", container::getEndpoint);
-        registry.add("app.search.api-key", container::getMasterKey);
-    }
-}
-```
-
-### Index documents and wait for tasks
-
-```java
-@Container
-static MeilisearchContainer container = new MeilisearchContainer()
-    .withMasterKey("masterKey");
-
-Client client = new Client(new Config(container.getEndpoint(), container.getMasterKey()));
-String indexUid = "movies";
-Index index = client.index(indexUid);
-
-TaskInfo createIndexTask = client.createIndex(indexUid, "id");
-index.waitForTask(createIndexTask.getTaskUid(), 15000, 100);
-
-String documents = "["
-    + "{\"id\":1,\"title\":\"Dune\"},"
-    + "{\"id\":2,\"title\":\"Foundation\"}"
-    + "]";
-TaskInfo addDocumentsTask = index.addDocuments(documents);
-index.waitForTask(addDocumentsTask.getTaskUid(), 15000, 100);
-```
-
-### Import a dump fixture
-
-```java
-@Container
-static MeilisearchContainer container = new MeilisearchContainer()
-    .withMasterKey("masterKey")
-    .withDumpImport("meilisearch/fixtures/movies.dump");
-```
-
-### Import a snapshot fixture
-
-```java
-@Container
-static MeilisearchContainer container = new MeilisearchContainer()
-    .withMasterKey("masterKey")
-    .withSnapshotImport("meilisearch/fixtures/movies.snapshot");
-```
-
-Snapshots are exact copies of Meilisearch data and must be created with the same
-Meilisearch version as the container image that imports them. Use dumps when you
-need a fixture that can move across Meilisearch versions.
-
-Dump and snapshot imports are strict by default. Only one import source can be
-configured per container, and dump helpers only apply to dump imports while
-snapshot helpers only apply to snapshot imports. Add the matching helpers when
-you want Meilisearch to keep an existing database instead of importing a fixture:
-
-```java
-@Container
-static MeilisearchContainer container = new MeilisearchContainer()
-    .withDumpImport("meilisearch/fixtures/movies.dump")
-    .withIgnoreDumpIfDbExists();
-```
-
-```java
-@Container
-static MeilisearchContainer container = new MeilisearchContainer()
-    .withSnapshotImport("meilisearch/fixtures/movies.snapshot")
-    .withIgnoreSnapshotIfDbExists();
-```
+See [docs/usage.md](docs/usage.md) for full API examples.
 
 Setup
 ---

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can add it as a dependency to your project using the following snippets.
 ### Gradle
 
 ```groovy
-testImplementation 'io.vanslog:testcontainers-meilisearch:1.1.0'
+testImplementation 'io.vanslog:testcontainers-meilisearch:1.2.0'
 ```
 
 ### Maven
@@ -53,7 +53,7 @@ testImplementation 'io.vanslog:testcontainers-meilisearch:1.1.0'
 <dependency>
     <groupId>io.vanslog</groupId>
     <artifactId>testcontainers-meilisearch</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,210 @@
+# Usage Guide
+
+This guide shows the main `MeilisearchContainer` API for JUnit 5, Spring Boot,
+the Meilisearch Java SDK, and fixture imports.
+
+## Start a container
+
+Use the default Meilisearch image:
+
+```java
+@Container
+MeilisearchContainer container = new MeilisearchContainer();
+```
+
+Use a custom compatible image when your tests need a specific Meilisearch
+version:
+
+```java
+@Container
+MeilisearchContainer container = new MeilisearchContainer(
+    DockerImageName.parse("getmeili/meilisearch:v1.43.0"));
+```
+
+## Configure runtime options
+
+Configure a master key for authenticated tests:
+
+```java
+@Container
+MeilisearchContainer container = new MeilisearchContainer()
+    .withMasterKey("masterKey");
+```
+
+Configure the Meilisearch environment mode with the enum values
+`MeilisearchEnvMode.DEVELOPMENT` or `MeilisearchEnvMode.PRODUCTION`:
+
+```java
+@Container
+MeilisearchContainer container = new MeilisearchContainer()
+    .withEnvMode(MeilisearchEnvMode.DEVELOPMENT);
+```
+
+The string overload is also available:
+
+```java
+@Container
+MeilisearchContainer container = new MeilisearchContainer()
+    .withEnvMode("development");
+```
+
+Configure the log level with `MeilisearchLogLevel.OFF`, `ERROR`, `WARN`, `INFO`,
+`DEBUG`, or `TRACE`:
+
+```java
+@Container
+MeilisearchContainer container = new MeilisearchContainer()
+    .withLogLevel(MeilisearchLogLevel.DEBUG);
+```
+
+The string overload is also available:
+
+```java
+@Container
+MeilisearchContainer container = new MeilisearchContainer()
+    .withLogLevel("DEBUG");
+```
+
+Disable Meilisearch analytics for the container:
+
+```java
+@Container
+MeilisearchContainer container = new MeilisearchContainer()
+    .withNoAnalytics();
+```
+
+## Connect with the Java SDK
+
+The container exposes helpers for the Meilisearch Java SDK:
+
+```java
+Client client = new Client(new Config(container.getEndpoint(), container.getMasterKey()));
+```
+
+Create an index, add documents, and wait for asynchronous tasks to finish:
+
+```java
+@Container
+static MeilisearchContainer container = new MeilisearchContainer()
+    .withMasterKey("masterKey");
+
+Client client = new Client(new Config(container.getEndpoint(), container.getMasterKey()));
+String indexUid = "movies";
+Index index = client.index(indexUid);
+
+TaskInfo createIndexTask = client.createIndex(indexUid, "id");
+index.waitForTask(createIndexTask.getTaskUid(), 15000, 100);
+
+String documents = "["
+    + "{\"id\":1,\"title\":\"Dune\"},"
+    + "{\"id\":2,\"title\":\"Foundation\"}"
+    + "]";
+TaskInfo addDocumentsTask = index.addDocuments(documents);
+index.waitForTask(addDocumentsTask.getTaskUid(), 15000, 100);
+```
+
+## Use with JUnit 5
+
+```java
+@Testcontainers
+class SearchTest {
+
+    @Container
+    static MeilisearchContainer container = new MeilisearchContainer()
+        .withMasterKey("masterKey");
+
+    @Test
+    void connectsWithSdk() {
+        Client client = new Client(new Config(container.getEndpoint(), container.getMasterKey()));
+    }
+}
+```
+
+## Use with Spring Boot
+
+For Spring Boot tests, register your own application properties from the
+container. Spring Boot 3.1+ can also wire custom containers through its
+Testcontainers support if you prefer.
+
+```java
+@Testcontainers
+@SpringBootTest
+class SearchIntegrationTest {
+
+    @Container
+    static MeilisearchContainer container = new MeilisearchContainer()
+        .withMasterKey("masterKey");
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("app.search.endpoint", container::getEndpoint);
+        registry.add("app.search.api-key", container::getMasterKey);
+    }
+}
+```
+
+## Import fixtures
+
+Import a dump fixture from the test classpath:
+
+```java
+@Container
+static MeilisearchContainer container = new MeilisearchContainer()
+    .withMasterKey("masterKey")
+    .withDumpImport("meilisearch/fixtures/movies.dump");
+```
+
+Import a dump fixture from a `MountableFile`:
+
+```java
+@Container
+static MeilisearchContainer container = new MeilisearchContainer()
+    .withMasterKey("masterKey")
+    .withDumpImport(MountableFile.forClasspathResource("meilisearch/fixtures/movies.dump"));
+```
+
+Import a snapshot fixture from the test classpath:
+
+```java
+@Container
+static MeilisearchContainer container = new MeilisearchContainer()
+    .withMasterKey("masterKey")
+    .withSnapshotImport("meilisearch/fixtures/movies.snapshot");
+```
+
+Import a snapshot fixture from a `MountableFile`:
+
+```java
+@Container
+static MeilisearchContainer container = new MeilisearchContainer()
+    .withMasterKey("masterKey")
+    .withSnapshotImport(MountableFile.forClasspathResource("meilisearch/fixtures/movies.snapshot"));
+```
+
+Snapshots are exact copies of Meilisearch data and must be created with the same
+Meilisearch version as the container image that imports them. Use dumps when you
+need a fixture that can move across Meilisearch versions.
+
+Dump and snapshot imports are strict by default. Only one import source can be
+configured per container. Dump helpers only apply to dump imports, and snapshot
+helpers only apply to snapshot imports.
+
+Keep an existing database instead of importing a dump fixture when `/meili_data`
+already contains data:
+
+```java
+@Container
+static MeilisearchContainer container = new MeilisearchContainer()
+    .withDumpImport("meilisearch/fixtures/movies.dump")
+    .withIgnoreDumpIfDbExists();
+```
+
+Keep an existing database instead of importing a snapshot fixture when
+`/meili_data` already contains data:
+
+```java
+@Container
+static MeilisearchContainer container = new MeilisearchContainer()
+    .withSnapshotImport("meilisearch/fixtures/movies.snapshot")
+    .withIgnoreSnapshotIfDbExists();
+```

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.vanslog</groupId>
   <artifactId>testcontainers-meilisearch</artifactId>
-  <version>1.1.1-SNAPSHOT</version>
+  <version>1.2.0</version>
 
   <name>testcontainers-meilisearch</name>
   <description>Testcontainers Meilisearch</description>


### PR DESCRIPTION
## Summary
- Bump the 1.x lane to `1.2.0` for the stable release.
- Update README dependency snippets to `1.2.0`.
- Keep README concise by moving detailed API examples to `docs/usage.md`.

## Verification
- `JAVA_HOME="$(/usr/libexec/java_home -v 21)" ./mvnw -B -ntp clean verify`
- LSP diagnostics clean for `pom.xml`, `README.md`, and `docs/usage.md`
- Confirmed `docs/usage.md` is linked from README and release snippets use `1.2.0`