### PR TITLE
release: v2.0.0

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Development
 
-This project is a Java 11-compatible Testcontainers module for Meilisearch.
+The `main` / `v2.x` branch targets Java 17 or newer and Testcontainers 2.x.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can add it as a dependency to your project using the following snippets.
 ### Gradle
 
 ```groovy
-testImplementation 'io.vanslog:testcontainers-meilisearch:2.0.0-SNAPSHOT'
+testImplementation 'io.vanslog:testcontainers-meilisearch:2.0.0'
 ```
 
 ### Maven
@@ -53,7 +53,7 @@ testImplementation 'io.vanslog:testcontainers-meilisearch:2.0.0-SNAPSHOT'
 <dependency>
     <groupId>io.vanslog</groupId>
     <artifactId>testcontainers-meilisearch</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Setup
 
 This library is available in Maven Central.
 You can add it as a dependency to your project using the following snippets.
+The `v2.x` line targets Java 17 or newer and Testcontainers 2.x.
 
 ### Gradle
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
 
   <properties>
     <!-- Compiler -->
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <!-- Dependencies -->
     <testcontainers>2.0.5</testcontainers>
     <meilisearch-java>0.15.0</meilisearch-java>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.vanslog</groupId>
   <artifactId>testcontainers-meilisearch</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.0.0</version>
 
   <name>testcontainers-meilisearch</name>
   <description>Testcontainers Meilisearch</description>


### PR DESCRIPTION
## Summary
- Bump the main Testcontainers 2.x lane to `2.0.0` for the stable release.
- Update README dependency snippets to `2.0.0`.
- Release the v1.2.0-aligned feature baseline on Testcontainers 2.x.
- Set the v2 release artifact baseline to Java 17 and document it in README/DEVELOPMENT.

## Verification
- `JAVA_HOME="$(/usr/libexec/java_home -v 17)" ./mvnw -B -ntp clean verify`
- LSP diagnostics clean for `pom.xml`, `README.md`, and `DEVELOPMENT.md`
- Confirmed built classes target Java 17 (`major version: 61`)
- Confirmed latest `main` CI, Snapshot CD, and Release Drafter runs were green before branching